### PR TITLE
modified the selector to the correct label

### DIFF
--- a/templates/zabbix-web.service.yaml
+++ b/templates/zabbix-web.service.yaml
@@ -15,4 +15,4 @@ spec:
     targetPort: 8443
     name: web-https
   selector:
-    name: zabbix-web
+    app: zabbix-web


### PR DESCRIPTION
I think the selector for the zabbix-web Service was wrong, as it caused the Service to not have an active backend. The backend was created with a label "app=zabbix-web", which will now be referenced correctly. 

After this modification the zabbix-web Service had an active backend. 